### PR TITLE
bazaar.php: fix html form to act as a normal form by allowing ENTER to submit

### DIFF
--- a/templates/bazaar_body.tpl
+++ b/templates/bazaar_body.tpl
@@ -65,7 +65,7 @@ function display(type, id, prefix) {
                   <input class='Bazaar' name='pricemax' value='{PRICE_MAX}'><br>
                   <br>
                   <center>  
-                    <div class='FreeButton' onclick="document.bazaar.submit();">{L_SEARCH}</div>
+                    <input type='submit' class='FreeButton' value='{L_SEARCH}'>
                   </center>
                 </form>
               </td></tr>

--- a/templates/style.css
+++ b/templates/style.css
@@ -157,6 +157,12 @@ INPUT.search {
   margin: 0px;
 }
 
+INPUT.FreeButton {
+  font-family:arial;
+  color: #FFFFFF;
+  font-size: 9pt;
+}
+
 /* the byline in the footer*/
 .Footer {
   font-family:		georgia;


### PR DESCRIPTION
Previously the bazaar search required one to mouse click on the Search button.

My p2002 forum name is diggy.